### PR TITLE
Handle error thrown in worker (passing as object then calling Error() again)

### DIFF
--- a/src/rpc-worker-loader.js
+++ b/src/rpc-worker-loader.js
@@ -10,11 +10,14 @@ function workerSetup() {
 			else {
 				p = Promise.reject('No such method');
 			}
-			p.then(
-				result => {
+			p.then(result => {
 					postMessage({ type: 'RPC', id, result });
-				},
-				error => {
+				})
+				.catch(error => {
+					if (error.stack) {
+						postMessage({ type: 'RPC', id, error: { name: error.name, message: error.message, stack: error.stack } });
+						return;
+					}
 					postMessage({ type: 'RPC', id, error });
 				});
 		}

--- a/src/rpc-wrapper.js
+++ b/src/rpc-wrapper.js
@@ -8,7 +8,12 @@ export default function addMethods(worker, methods) {
 			let f = callbacks[d.id];
 			if (f) {
 				delete callbacks[d.id];
-				if (d.error) f[1](d.error);
+				if (d.error) {
+					let workerError = Error(d.error && d.error.message ? d.error.message : 'Error in worker');
+					if (d.error && d.error.stack) workerError.stack = d.error.stack;
+					if (d.error && d.error.name) workerError.name = d.error.name;
+					f[1](workerError);
+				}
 				else f[0](d.result);
 			}
 		}

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -19,6 +19,14 @@ describe('worker', () => {
 		expect(out).toEqual('a [bar:3] b');
 	});
 
+	it('worker.throwError() should pass the Error back to the application context', async () => {
+		try {
+			let out = await worker.throwError();
+		} catch (e) {
+			expect(e).toEqual(new Error('Error in worker.js'));
+		}
+	});
+
 	it('should fire ready event', done => {
 		let worker = new Worker(),
 			called = false,

--- a/test/src/worker.js
+++ b/test/src/worker.js
@@ -6,6 +6,10 @@ export function foo() {
 	return 1;
 }
 
+export function throwError() {
+	throw new Error('Error in worker.js');
+}
+
 export function bar(a, b) {
 	return `${a} [bar:${otherBar}] ${b}`;
 }


### PR DESCRIPTION
Also, added test that call a method that throws inside the worker.