### PR TITLE
Save the exported method names in a local cache object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ loader.pitch = function(request) {
 				// only process entry exports
 				if (current.resource!==entry) return;
 
-				let exports = compilation.__workerizeExports || (compilation.__workerizeExports = {});
+				let exports = CACHE[entry] || (CACHE[entry] = {});
 
 				if (decl.id) {
 					exports[decl.id.name] = true;
@@ -106,8 +106,9 @@ loader.pitch = function(request) {
 		if (entries[0]) {
 			worker.file = entries[0].files[0];
 
+			let entry = entries[0].entryModule.resource;
 			let contents = compilation.assets[worker.file].source();
-			let exports = Object.keys(CACHE[worker.file] = compilation.__workerizeExports || CACHE[worker.file] || {});
+			let exports = Object.keys(CACHE[entry] || {});
 
 			// console.log('Workerized exports: ', exports.join(', '));
 


### PR DESCRIPTION
Save the exported method names in a local cache object, per entry file, instead of using the compilation object. Fixes #24 where worker methods are undefined after a recompile.

Since this is the first webpack loader I've touched, this PR might need further changes. But using the CACHE object like this works, as opposed to using the compilation object which doesn't work after a recompile.

This PR is meant to illustrate the problem, there might be a better way to fix it.