### PR TITLE
Add separate build for web target

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "dist/index.js",
   "repository": "developit/workerize-loader",
   "scripts": {
-    "build": "microbundle --target node --format cjs --no-compress src/*.js",
+    "build": "npm run build-loader && npm run build-rpc",
+    "build-loader": "microbundle --target node --format cjs --no-compress src/index.js ",
+    "build-rpc": "microbundle --target web --format cjs --no-compress src/rpc-*.js",
     "prepublishOnly": "npm run build",
     "dev": "karmatic watch --no-headless",
     "test": "npm run build && karmatic && NODE_ENV=production karmatic -p",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workerize-loader",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Automatically move a module into a Web Worker (Webpack loader)",
   "main": "dist/index.js",
   "repository": "developit/workerize-loader",


### PR DESCRIPTION
After upgrade from **1.1.0** to **1.2.0**/**1.2.1**  we noticed that workers stopped working in **IE** (arrow functions caused syntax error). It seems to be related to **microbundle** upgrade [here](https://github.com/developit/workerize-loader/compare/1.1.0...1.2.0#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R39)
This commit just adds separate build with target 'web' so both 'rpc-wrapper.js' and 'rpc-worker-loader.js' can be executed without having syntax error in old environments.

I didn't find a better way than just adding another build command. Maybe there is a better way to do that with **microbundle** 