### PR TITLE
Add support for imported exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,12 @@ loader.pitch = function(request) {
 
 			let key = entries[0].entryModule.nameForCondition();
 			let contents = compilation.assets[worker.file].source();
-			let exports = Object.keys(CACHE[key] || {});
+			let exports = Array.from(
+				new Set([
+					...Object.keys(CACHE[key] || {}),
+					...entries[0].entryModule.buildMeta.providedExports
+				])
+			);
 
 			// console.log('Workerized exports: ', exports.join(', '));
 

--- a/test/src/and-the-other.js
+++ b/test/src/and-the-other.js
@@ -1,0 +1,9 @@
+export function otherOtherFoo() {
+	return 2;
+}
+
+export function anyFoo() {
+	return 4;
+}
+
+export const otherOtherBar = 3;

--- a/test/src/common.js
+++ b/test/src/common.js
@@ -1,0 +1,3 @@
+exports.tragedy = function tragedy() {
+	return 'common';
+};

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -8,11 +8,31 @@ describe('worker', () => {
 
 	it('should be an instance of Worker', () => {
 		worker = new Worker();
+		// eslint-disable-next-line jest/no-jasmine-globals
 		expect(worker).toEqual(jasmine.any(window.Worker));
 	});
 
 	it('worker.foo()', async () => {
 		expect(await worker.foo()).toBe(1);
+	});
+
+	it('worker.otherFoo()', async () => {
+		expect(await worker.otherFoo()).toBe(-1);
+	});
+
+	it('worker.otherOtherFoo()', async () => {
+		expect(await worker.otherOtherFoo()).toBe(2);
+	});
+	it('worker.andTheOtherFoo()', async () => {
+		expect(await worker.andTheOtherFoo()).toBe(2);
+	});
+
+	it('worker.anyFoo()', async () => {
+		expect(await worker.anyFoo()).toBe(4);
+	});
+
+	it('worker.tragedy()', async () => {
+		expect(await worker.tragedy()).toBe('common');
 	});
 
 	it('worker.bar()', async () => {
@@ -102,6 +122,7 @@ describe('?import option', () => {
 
 	it('should be an instance of Worker', () => {
 		worker = new ImportWorker();
+		// eslint-disable-next-line jest/no-jasmine-globals
 		expect(worker).toEqual(jasmine.any(window.Worker));
 	});
 

--- a/test/src/other.js
+++ b/test/src/other.js
@@ -1,3 +1,5 @@
-export function otherFoo() {}
+export function otherFoo() {
+	return -1;
+}
 
 export const otherBar = 3;

--- a/test/src/worker.js
+++ b/test/src/worker.js
@@ -1,10 +1,16 @@
 import { otherFoo, otherBar } from './other';
 
 export { otherFoo };
+export { otherOtherFoo as andTheOtherFoo } from './and-the-other';
+export * from './and-the-other';
+
+export { tragedy } from './common.js';
 
 export function foo() {
 	return 1;
 }
+
+export const value = 3;
 
 export function throwError() {
 	throw new Error('Error in worker.js');


### PR DESCRIPTION
Adds support for

```
export * from 'module';
export { function } from 'module'
```

`providedExports` field appears to be around for all of Webpack 4. If prior webpacks are supported still, then will need a simple adapter layer.

Approached this in additive fashion to reduce the risk of this PR. I do have a stash locally that replaces the custom traversal logic glad to include that in this PR if desired. Mostly deletes the custom parser hooks.

Fixes #15 