### PR TITLE
Support webpack 5

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ loader.pitch = function(request) {
 		if (err) return cb(err);
 
 		if (entries[0]) {
-			worker.file = entries[0].files[0];
+			worker.file = Array.from(entries[0].files)[0];
 
 			let contents = compilation.assets[worker.file].source();
 

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,12 @@ loader.pitch = function(request) {
 
 			let key = entries[0].entryModule.nameForCondition();
 			let contents = compilation.assets[worker.file].source();
-			let exports = Object.keys(CACHE[key] || {});
+			let exports = Array.from(
+				new Set([
+					...Object.keys(CACHE[key] || {}),
+					...entries[0].entryModule.buildMeta.providedExports
+				])
+			);
 
 			// console.log('Workerized exports: ', exports.join(', '));
 

--- a/test/src/and-the-other.js
+++ b/test/src/and-the-other.js
@@ -1,0 +1,9 @@
+export function otherOtherFoo() {
+	return 2;
+}
+
+export function anyFoo() {
+	return 4;
+}
+
+export const otherOtherBar = 3;

--- a/test/src/common.js
+++ b/test/src/common.js
@@ -1,0 +1,3 @@
+exports.tragedy = function tragedy() {
+	return 'common';
+};

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -8,11 +8,31 @@ describe('worker', () => {
 
 	it('should be an instance of Worker', () => {
 		worker = new Worker();
+		// eslint-disable-next-line jest/no-jasmine-globals
 		expect(worker).toEqual(jasmine.any(window.Worker));
 	});
 
 	it('worker.foo()', async () => {
 		expect(await worker.foo()).toBe(1);
+	});
+
+	it('worker.otherFoo()', async () => {
+		expect(await worker.otherFoo()).toBe(-1);
+	});
+
+	it('worker.otherOtherFoo()', async () => {
+		expect(await worker.otherOtherFoo()).toBe(2);
+	});
+	it('worker.andTheOtherFoo()', async () => {
+		expect(await worker.andTheOtherFoo()).toBe(2);
+	});
+
+	it('worker.anyFoo()', async () => {
+		expect(await worker.anyFoo()).toBe(4);
+	});
+
+	it('worker.tragedy()', async () => {
+		expect(await worker.tragedy()).toBe('common');
 	});
 
 	it('worker.bar()', async () => {
@@ -102,6 +122,7 @@ describe('?import option', () => {
 
 	it('should be an instance of Worker', () => {
 		worker = new ImportWorker();
+		// eslint-disable-next-line jest/no-jasmine-globals
 		expect(worker).toEqual(jasmine.any(window.Worker));
 	});
 

--- a/test/src/other.js
+++ b/test/src/other.js
@@ -1,3 +1,5 @@
-export function otherFoo() {}
+export function otherFoo() {
+	return -1;
+}
 
 export const otherBar = 3;

--- a/test/src/worker.js
+++ b/test/src/worker.js
@@ -1,10 +1,16 @@
 import { otherFoo, otherBar } from './other';
 
 export { otherFoo };
+export { otherOtherFoo as andTheOtherFoo } from './and-the-other';
+export * from './and-the-other';
+
+export { tragedy } from './common.js';
 
 export function foo() {
 	return 1;
 }
+
+export const value = 3;
 
 export function throwError() {
 	throw new Error('Error in worker.js');


### PR DESCRIPTION
Expands on/supersedes #100. Removing the parser logic simplifies the webpack API integration and number of points that break as a result of webpack 5 changes.

Note that karma-webpack would not play nicely when I installed webpack 5, so while this appears to compile correctly, it has not been tested at runtime with Webpack 5.

Possible fix for #77